### PR TITLE
Support partial PSBT signature functionality

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -394,7 +394,9 @@ async function onSignPsbt({ data = {}, sendResponse } = {}) {
       data.rawTx,
       data.indexes,
       decryptedWallet.children[data.selectedAddressIndex],
-      !data.feeOnly
+      !data.feeOnly,
+      data.partial,
+      data.sighashType,
     );
 
     sendResponse?.({

--- a/scripts/helpers/constants.js
+++ b/scripts/helpers/constants.js
@@ -12,6 +12,16 @@ export const NFT_PAGE_SIZE = 500;
 export const QUERY_CACHE = '@mydoge_QUERY_CACHE';
 export const INSCRIPTION_TXS_CACHE = '@mydoge_INSCRIPTION_TXS_CACHE';
 export const SPENT_UTXOS_CACHE = '@mydoge_SPENT_UTXOS_CACHE';
+/**
+ * Whitelist of supported signature hash types:
+ * - 1 (0x01): SIGHASH_ALL - Signs all inputs and outputs
+ * - 3 (0x03): SIGHASH_SINGLE - Signs all inputs and the output with the same index
+ * - 128 (0x80): SIGHASH_ANYONECANPAY - Can be combined with ALL/SINGLE
+ * - 129 (0x81): SIGHASH_ALL|SIGHASH_ANYONECANPAY - Signs one input and all outputs
+ * - 131 (0x83): SIGHASH_SINGLE|SIGHASH_ANYONECANPAY - Signs one input and one output at same index
+ * Note: SIGHASH_NONE (2) is not supported for security reasons
+ */
+export const SIGHASH_TYPE_WHITELIST = [1, 3, 128, 129, 131];
 
 export const BLOCK_CONFIRMATIONS = 1;
 export const TRANSACTION_PAGE_SIZE = 10;

--- a/scripts/inject-script.js
+++ b/scripts/inject-script.js
@@ -346,6 +346,16 @@ class MyDogeWallet {
    * @param {string} data.rawTx - The raw transaction to be signed.
    * @param {number[]} data.indexes - The indexes of the inputs to be signed.
    * @param {boolean} data.signOnly - A flag to indicate whether to return the raw tx after signing instead of signing + sending (default: false)
+   * @param {boolean} data.partial - A flag to indicate whether to create partial signatures. Only effective when signOnly is true (default: false)
+   * @param {number} data.sighashType - The signature hash type to use. Only effective when partial is true. Possible values:
+   *                                   - SIGHASH_ALL (0x01): Signs all inputs and outputs (default)
+   *                                   - SIGHASH_SINGLE (0x03): Signs all inputs, and the output with the same index
+   *                                   - SIGHASH_ANYONECANPAY (0x80): Can be combined with above types using bitwise OR
+   *                                   Combinations:
+   *                                   - SIGHASH_ALL|SIGHASH_ANYONECANPAY (0x81): Signs one input and all outputs
+   *                                   - SIGHASH_SINGLE|SIGHASH_ANYONECANPAY (0x83): Signs one input and one output at same index
+   *                                   Note: 
+   *                                   - SIGHASH_NONE (0x02) is not supported for security reasons - it signs inputs but no outputs, allowing transaction outputs to be modified after signing
    * @param {function({ txId: string }): void} [onSuccess] - Optional callback function to execute upon successful signing.
    *                                                           Receives an object containing the transaction ID.
    * @param {function(string): void} [onError] - Callback function to execute upon error in signing the PSBT.


### PR DESCRIPTION
This PR extends MyDoge wallet's PSBT signing capabilities by adding support for additional SIGHASH types:
- SIGHASH_SINGLE
- SIGHASH_ANYONECANPAY
- SIGHASH_SINGLE | SIGHASH_ANYONECANPAY
- SIGHASH_ALL | SIGHASH_ANYONECANPAY

Necessity and Benefits:
1. NFT Trading Support
   - Enables direct participation in NFT marketplaces
   - Supports atomic swaps and listing orders
   - Essential for Doginals and DRC-20 token trading

2. Enhanced Transaction Flexibility
   - Allows partial transaction signing
   - Supports more complex transaction structures

3. Market Compatibility
   - Aligns with industry standards
   - Improves interoperability with other wallets

4. User Experience
   - Users can participate in more Dogecoin ecosystem activities

Technical Impact:
- Maintains existing SIGHASH_ALL functionality
- Adds new signing options without compromising security
- Follows Dogecoin protocol standards